### PR TITLE
Fix domain deletion date JSON unmarshal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x]
+        go-version: [1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, 1.22.x]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 

--- a/domains.go
+++ b/domains.go
@@ -17,7 +17,7 @@ type Domain struct {
 	LockStatus       string             `json:"lock_status"`
 	RegistrationDate *PnTime            `json:"registration_date"`
 	ExpirationDate   *PnTime            `json:"expiration_date"`
-	DeletionDate     *PnTime            `json:"deletion_date"`
+	DeletionDate     *PnDate            `json:"deletion_date"`
 	Status           string             `json:"status"`
 	NameServers      *NameServers       `json:"name_servers"`
 	ChildNameServers []*ChildNameServer `json:"child_name_servers"`

--- a/domains_test.go
+++ b/domains_test.go
@@ -24,7 +24,7 @@ var wantDomainInfo = &Domain{
 	LockStatus:       "unlocked",
 	RegistrationDate: &PnTime{wantDate},
 	ExpirationDate:   &PnTime{wantDate},
-	DeletionDate:     &PnTime{wantDate},
+	DeletionDate:     &PnDate{wantDateOnly},
 	Status:           "ok",
 	NameServers:      &NameServers{"string"},
 	ChildNameServers: []*ChildNameServer{{

--- a/pananames.go
+++ b/pananames.go
@@ -27,6 +27,10 @@ type PnTime struct {
 	time.Time
 }
 
+type PnDate struct {
+	time.Time
+}
+
 // Represents api client
 type Client struct {
 	httpClient *http.Client
@@ -83,6 +87,20 @@ func (t *PnTime) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 	return t.Time.UnmarshalJSON(data)
+}
+
+func (d *PnDate) UnmarshalJSON(data []byte) error {
+	val := strings.Trim(string(data), `"`)
+	if val == "" {
+		return nil
+	}
+
+	var err error
+	if d.Time, err = time.Parse(time.DateOnly, val); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (e *ErrorResponse) Error() string {
@@ -295,7 +313,7 @@ func fixZeroDate(value interface{}) {
 	}
 }
 
-// Set &PnTime to nil if it zero PnTime
+// Set &PnTime or &PnDate to nil if it zero PnTime or PnDate
 // If not, continue parse with fixZeroDate()
 func zeroPnTime(v reflect.Value) {
 	if v.IsZero() {
@@ -303,6 +321,12 @@ func zeroPnTime(v reflect.Value) {
 	}
 	if v.Type() == reflect.TypeOf(&PnTime{}) {
 		if t, ok := v.Elem().Interface().(PnTime); ok {
+			if t.IsZero() {
+				v.Set(reflect.Zero(v.Type()))
+			}
+		}
+	} else if v.Type() == reflect.TypeOf(&PnDate{}) {
+		if t, ok := v.Elem().Interface().(PnDate); ok {
 			if t.IsZero() {
 				v.Set(reflect.Zero(v.Type()))
 			}

--- a/pananames.go
+++ b/pananames.go
@@ -96,7 +96,7 @@ func (d *PnDate) UnmarshalJSON(data []byte) error {
 	}
 
 	var err error
-	if d.Time, err = time.Parse(time.DateOnly, val); err != nil {
+	if d.Time, err = time.Parse("2006-01-02", val); err != nil {
 		return err
 	}
 

--- a/pananames_test.go
+++ b/pananames_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 var wantDate = time.Date(2020, time.January, 2, 3, 4, 5, 0, time.UTC)
+var wantDateOnly = time.Date(2020, time.January, 2, 0, 0, 0, 0, time.UTC)
 
 var wantContact = &Contact{
 	Org:     "string",

--- a/testdata/domain.json
+++ b/testdata/domain.json
@@ -8,7 +8,7 @@
       "lock_status": "unlocked",
       "registration_date": "2020-01-02T03:04:05Z",
       "expiration_date": "2020-01-02T03:04:05Z",
-      "deletion_date": "2020-01-02T03:04:05Z",
+      "deletion_date": "2020-01-02",
       "status": "ok",
       "name_servers": [
         "string"

--- a/testdata/domains.json
+++ b/testdata/domains.json
@@ -15,7 +15,7 @@
       "lock_status": "unlocked",
       "registration_date": "2020-01-02T03:04:05Z",
       "expiration_date": "2020-01-02T03:04:05Z",
-      "deletion_date": "2020-01-02T03:04:05Z",
+      "deletion_date": "2020-01-02",
       "status": "ok",
       "name_servers": [
         "string"


### PR DESCRIPTION
Actual domain info response:
```
{
    "data": {
        "domain": "test.com",
        "premium": false,
        "auto_renew": false,
        "whois_privacy": true,
        "lock_status": "client",
        "registration_date": "2023-03-04T11:48:22Z",
        "expiration_date": "2024-03-04T11:48:22Z",
        "deletion_date": "2024-04-12",
        "status": "redemption",
        "name_servers": [],
        "child_name_servers": []
    }
}
```
current method implementation returns error:
`status: 200, unable to parse response data: parsing time \"2024-04-12\" as \"2006-01-02T15:04:05Z07:00\": cannot parse \"\" as \"T\"`